### PR TITLE
New 'find and use' data section from docs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ open-source@newrelic.com.
 The New Relic Telemetry APIs are rate limited. Please reference the
 documentation for [New Relic Metrics
 API](https://docs.newrelic.com/docs/introduction-new-relic-metric-api) and [New
-Relic Trace API Requirements and
-Limits](https://docs.newrelic.com/docs/apm/distributed-tracing/trace-api/trace-api-general-requirements-limits)
+Relic Trace API requirements and
+limits](https://docs.newrelic.com/docs/apm/distributed-tracing/trace-api/trace-api-general-requirements-limits)
 on the specifics of the rate limits.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ of the OpenTelemetry Go client is released.
 
 ## Find and use your data
 
-For tips on how to find and query your data, see [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data).
+For tips on how to find and query your data in New Relic, see [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data).
 
 
 For general querying information, see:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# New Relic Go OpenTelemetry Exporter [![GoDoc](https://godoc.org/github.com/newrelic/opentelemetry-exporter-go/newrelic?status.svg)](https://godoc.org/github.com/newrelic/opentelemetry-exporter-go/newrelic)
+# New Relic Go OpenTelemetry exporter [![GoDoc](https://godoc.org/github.com/newrelic/opentelemetry-exporter-go/newrelic?status.svg)](https://godoc.org/github.com/newrelic/opentelemetry-exporter-go/newrelic)
 
 The `"github.com/newrelic/opentelemetry-exporter-go/newrelic"` package
 provides an exporter for sending OpenTelemetry data to New Relic.  Currently,
@@ -36,6 +36,15 @@ compatibility with future releases of the OpenTelemetry APIs.  Additionally,
 this exporter may introduce changes that are not backwards compatible without a major
 version increment.  We will strive to ensure backwards compatibility when a stable version
 of the OpenTelemetry Go client is released.
+
+## Find and use your data
+
+For tips on how to find and query your data, see [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data).
+
+
+For general querying information, see:
+- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
 
 ## Licensing
 The New Relic Go OpenTelemetry exporter is licensed under the Apache 2.0 License.


### PR DESCRIPTION
This is from Zach Elwood on NR docs team. 

This PR is to add a ‘how to find data’ section so that customers can find the data they send. I’ve included what I think are the applicable data types [metrics] but let me know if there are other data types reported by this exporter. If you think this exporter will change to send other types of data in future, keep in mind it will be important to update this repo with link to that data type.

Also changed title to sentence case; small thing but we want headings to be sentence case and not title case, so just something to keep in mind when creating new content. 