### PR TITLE
Add Metric Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.2.0
-	go.opentelemetry.io/otel v0.3.0
+	go.opentelemetry.io/otel v0.4.3
 	google.golang.org/grpc v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-go.opentelemetry.io/otel v0.3.0 h1:x3i+dwRyD5ADPdGGF6uf8KnqxC5b3vpyvo7b2YLocEc=
-go.opentelemetry.io/otel v0.3.0/go.mod h1:OgNpQOjrlt33Ew6Ds0mGjmcTQg/rhUctsbkRdk/g1fw=
+go.opentelemetry.io/otel v0.4.3 h1:CroUX/0O1ZDcF0iWOO8gwYFWb5EbdSF0/C1yosO+Vhs=
+go.opentelemetry.io/otel v0.4.3/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/newrelic/exporter.go
+++ b/newrelic/exporter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/newrelic/opentelemetry-exporter-go/newrelic/internal/transform"
 	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
 	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/resource"
 )
 
 const (
@@ -77,9 +78,9 @@ func (e *Exporter) ExportSpan(ctx context.Context, span *tracesdk.SpanData) {
 }
 
 // Export exports metrics to New Relic.
-func (e *Exporter) Export(_ context.Context, cps metricsdk.CheckpointSet) error {
+func (e *Exporter) Export(_ context.Context, r *resource.Resource, cps metricsdk.CheckpointSet) error {
 	return cps.ForEach(func(record metricsdk.Record) error {
-		m, err := transform.Record(e.serviceName, record)
+		m, err := transform.Record(e.serviceName, r, record)
 		if err != nil {
 			return err
 		}

--- a/newrelic/exporter.go
+++ b/newrelic/exporter.go
@@ -10,7 +10,8 @@ import (
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"github.com/newrelic/opentelemetry-exporter-go/newrelic/internal/transform"
-	"go.opentelemetry.io/otel/sdk/export/trace"
+	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
+	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
 )
 
 const (
@@ -55,23 +56,34 @@ func NewExporter(serviceName, apiKey string, options ...func(*telemetry.Config))
 }
 
 var (
-	_ interface {
-		trace.SpanSyncer
-		trace.SpanBatcher
-	} = &Exporter{}
+	_ tracesdk.SpanSyncer  = (*Exporter)(nil)
+	_ tracesdk.SpanBatcher = (*Exporter)(nil)
+	_ metricsdk.Exporter   = (*Exporter)(nil)
 )
 
 // ExportSpans exports multiple spans to New Relic.
-func (e *Exporter) ExportSpans(ctx context.Context, spans []*trace.SpanData) {
+func (e *Exporter) ExportSpans(ctx context.Context, spans []*tracesdk.SpanData) {
 	for _, s := range spans {
 		e.ExportSpan(ctx, s)
 	}
 }
 
 // ExportSpan exports a span to New Relic.
-func (e *Exporter) ExportSpan(ctx context.Context, span *trace.SpanData) {
+func (e *Exporter) ExportSpan(ctx context.Context, span *tracesdk.SpanData) {
 	if nil == e {
 		return
 	}
 	e.harvester.RecordSpan(transform.Span(e.serviceName, span))
+}
+
+// Export exports metrics to New Relic.
+func (e *Exporter) Export(_ context.Context, cps metricsdk.CheckpointSet) error {
+	return cps.ForEach(func(record metricsdk.Record) error {
+		m, err := transform.Record(e.serviceName, record)
+		if err != nil {
+			return err
+		}
+		e.harvester.RecordMetric(m)
+		return nil
+	})
 }

--- a/newrelic/exporter_test.go
+++ b/newrelic/exporter_test.go
@@ -181,7 +181,7 @@ func TestEndToEndTracer(t *testing.T) {
 
 	gotSpans := mockt.Spans()
 	if got := len(gotSpans); got != numSpans {
-		t.Errorf("expecting %d spans, got %d", numSpans, got)
+		t.Fatalf("expecting %d spans, got %d", numSpans, got)
 	}
 
 	var traceID, parentID string

--- a/newrelic/exporter_test.go
+++ b/newrelic/exporter_test.go
@@ -18,7 +18,12 @@ import (
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"go.opentelemetry.io/otel/api/core"
+	"go.opentelemetry.io/otel/api/metric"
+	metricapi "go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/metric/batcher/ungrouped"
+	"go.opentelemetry.io/otel/sdk/metric/controller/push"
+	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -51,6 +56,14 @@ func (c *MockTransport) Spans() []Span {
 		spans = append(spans, data.Spans...)
 	}
 	return spans
+}
+
+func (c *MockTransport) Metrics() []Metric {
+	var metrics []Metric
+	for _, data := range c.Data {
+		metrics = append(metrics, data.Metrics...)
+	}
+	return metrics
 }
 
 func (c *MockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -197,6 +210,145 @@ func TestEndToEndTracer(t *testing.T) {
 		}
 		if got := s.Attributes["depth"].(float64); got != float64(depth) {
 			t.Errorf("span 'depth' for %s: got %g, want %d", name, got, depth)
+		}
+	}
+}
+
+func TestEndToEndMeter(t *testing.T) {
+	serviceName := "opentelemetry-service"
+	type data struct {
+		iKind metric.Kind
+		nKind core.NumberKind
+		val   int64
+	}
+	instruments := map[string]data{
+		"test-int64-counter":    {metric.CounterKind, core.Int64NumberKind, 1},
+		"test-float64-counter":  {metric.CounterKind, core.Float64NumberKind, 1},
+		"test-int64-measure":    {metric.MeasureKind, core.Int64NumberKind, 2},
+		"test-float64-measure":  {metric.MeasureKind, core.Float64NumberKind, 2},
+		"test-int64-observer":   {metric.ObserverKind, core.Int64NumberKind, 3},
+		"test-float64-observer": {metric.ObserverKind, core.Float64NumberKind, 3},
+	}
+
+	mockt := &MockTransport{
+		Data: make([]Data, 0, len(instruments)),
+	}
+	e, err := NewExporter(
+		serviceName,
+		"apiKey",
+		telemetry.ConfigHarvestPeriod(0),
+		telemetry.ConfigBasicErrorLogger(os.Stderr),
+		telemetry.ConfigBasicDebugLogger(os.Stderr),
+		telemetry.ConfigBasicAuditLogger(os.Stderr),
+		func(cfg *telemetry.Config) {
+			cfg.MetricsURLOverride = "localhost"
+			cfg.SpansURLOverride = "localhost"
+			cfg.Client.Transport = mockt
+		},
+	)
+	if err != nil {
+		t.Fatalf("failed to instantiate exporter: %v", err)
+	}
+
+	selector := simple.NewWithExactMeasure()
+	batcher := ungrouped.New(selector, true)
+	pusher := push.New(batcher, e, 60*time.Second)
+	pusher.Start()
+
+	ctx := context.Background()
+	meter := pusher.Meter("test-meter")
+
+	for name, data := range instruments {
+		switch data.iKind {
+		case metric.CounterKind:
+			switch data.nKind {
+			case core.Int64NumberKind:
+				metricapi.Must(meter).NewInt64Counter(name).Add(ctx, data.val, nil)
+			case core.Float64NumberKind:
+				metricapi.Must(meter).NewFloat64Counter(name).Add(ctx, float64(data.val), nil)
+			default:
+				t.Fatal("unsupported number testing kind", data.nKind.String())
+			}
+		case metric.MeasureKind:
+			switch data.nKind {
+			case core.Int64NumberKind:
+				metricapi.Must(meter).NewInt64Measure(name).Record(ctx, data.val, nil)
+			case core.Float64NumberKind:
+				metricapi.Must(meter).NewFloat64Measure(name).Record(ctx, float64(data.val), nil)
+			default:
+				t.Fatal("unsupported number testing kind", data.nKind.String())
+			}
+		case metric.ObserverKind:
+			switch data.nKind {
+			case core.Int64NumberKind:
+				callback := func(v int64) metricapi.Int64ObserverCallback {
+					return metricapi.Int64ObserverCallback(func(result metricapi.Int64ObserverResult) { result.Observe(v, nil) })
+				}(data.val)
+				metricapi.Must(meter).RegisterInt64Observer(name, callback)
+			case core.Float64NumberKind:
+				callback := func(v float64) metricapi.Float64ObserverCallback {
+					return metricapi.Float64ObserverCallback(func(result metricapi.Float64ObserverResult) { result.Observe(v, nil) })
+				}(float64(data.val))
+				metricapi.Must(meter).RegisterFloat64Observer(name, callback)
+			default:
+				t.Fatal("unsupported number testing kind", data.nKind.String())
+			}
+		default:
+			t.Fatal("unsupported metrics testing kind", data.iKind.String())
+		}
+	}
+
+	// Wait >2 cycles.
+	<-time.After(40 * time.Millisecond)
+
+	// Flush and close.
+	pusher.Stop()
+	e.harvester.HarvestNow(ctx)
+
+	gotMetrics := mockt.Metrics()
+	if got, want := len(gotMetrics), len(instruments); got != want {
+		t.Fatalf("expecting %d spans, got %d", want, got)
+	}
+	seen := make(map[string]struct{}, len(instruments))
+	for _, m := range gotMetrics {
+		want, ok := instruments[m.Name]
+		if !ok {
+			t.Fatal("unknown metrics", m.Name)
+			continue
+		}
+		seen[m.Name] = struct{}{}
+
+		switch want.iKind {
+		case metric.CounterKind:
+			if m.Type != "count" {
+				t.Errorf("metric type for %s: got %q, want \"counter\"", m.Name, m.Type)
+			}
+			if got := m.Value.(float64); got != float64(want.val) {
+				t.Errorf("metric value for %s: got %g, want %d", m.Name, m.Value, want.val)
+			}
+		case metric.MeasureKind, metric.ObserverKind:
+			if m.Type != "summary" {
+				t.Errorf("metric type for %s: got %q, want \"summary\"", m.Name, m.Type)
+			}
+			value := m.Value.(map[string]interface{})
+			if got := value["count"].(float64); got != 1 {
+				t.Errorf("metric value for %s: got %g, want %d", m.Name, m.Value, 1)
+			}
+			if got := value["sum"].(float64); got != float64(want.val) {
+				t.Errorf("metric value for %s: got %g, want %d", m.Name, m.Value, want.val)
+			}
+			if got := value["min"].(float64); got != float64(want.val) {
+				t.Errorf("metric value for %s: got %g, want %d", m.Name, m.Value, want.val)
+			}
+			if got := value["max"].(float64); got != float64(want.val) {
+				t.Errorf("metric value for %s: got %g, want %d", m.Name, m.Value, want.val)
+			}
+		}
+	}
+
+	for i := range instruments {
+		if _, ok := seen[i]; !ok {
+			t.Errorf("no metric(s) exported for %q", i)
 		}
 	}
 }

--- a/newrelic/exporter_test.go
+++ b/newrelic/exporter_test.go
@@ -263,18 +263,18 @@ func TestEndToEndMeter(t *testing.T) {
 		case metric.CounterKind:
 			switch data.nKind {
 			case core.Int64NumberKind:
-				metricapi.Must(meter).NewInt64Counter(name).Add(ctx, data.val, nil)
+				metricapi.Must(meter).NewInt64Counter(name).Add(ctx, data.val)
 			case core.Float64NumberKind:
-				metricapi.Must(meter).NewFloat64Counter(name).Add(ctx, float64(data.val), nil)
+				metricapi.Must(meter).NewFloat64Counter(name).Add(ctx, float64(data.val))
 			default:
 				t.Fatal("unsupported number testing kind", data.nKind.String())
 			}
 		case metric.MeasureKind:
 			switch data.nKind {
 			case core.Int64NumberKind:
-				metricapi.Must(meter).NewInt64Measure(name).Record(ctx, data.val, nil)
+				metricapi.Must(meter).NewInt64Measure(name).Record(ctx, data.val)
 			case core.Float64NumberKind:
-				metricapi.Must(meter).NewFloat64Measure(name).Record(ctx, float64(data.val), nil)
+				metricapi.Must(meter).NewFloat64Measure(name).Record(ctx, float64(data.val))
 			default:
 				t.Fatal("unsupported number testing kind", data.nKind.String())
 			}
@@ -282,12 +282,12 @@ func TestEndToEndMeter(t *testing.T) {
 			switch data.nKind {
 			case core.Int64NumberKind:
 				callback := func(v int64) metricapi.Int64ObserverCallback {
-					return metricapi.Int64ObserverCallback(func(result metricapi.Int64ObserverResult) { result.Observe(v, nil) })
+					return metricapi.Int64ObserverCallback(func(result metricapi.Int64ObserverResult) { result.Observe(v) })
 				}(data.val)
 				metricapi.Must(meter).RegisterInt64Observer(name, callback)
 			case core.Float64NumberKind:
 				callback := func(v float64) metricapi.Float64ObserverCallback {
-					return metricapi.Float64ObserverCallback(func(result metricapi.Float64ObserverResult) { result.Observe(v, nil) })
+					return metricapi.Float64ObserverCallback(func(result metricapi.Float64ObserverResult) { result.Observe(v) })
 				}(float64(data.val))
 				metricapi.Must(meter).RegisterFloat64Observer(name, callback)
 			default:

--- a/newrelic/internal/transform/identifiers.go
+++ b/newrelic/internal/transform/identifiers.go
@@ -7,6 +7,8 @@ const (
 	errorCodeAttrKey    = "error.code"
 	errorMessageAttrKey = "error.message"
 
+	serviceNameAttrKey = "service.name"
+
 	instrumentationProviderAttrKey   = "instrumentation.provider"
 	instrumentationProviderAttrValue = "opentelemetry"
 

--- a/newrelic/internal/transform/metric.go
+++ b/newrelic/internal/transform/metric.go
@@ -1,0 +1,110 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package transform
+
+import (
+	"errors"
+
+	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"go.opentelemetry.io/otel/api/core"
+	"go.opentelemetry.io/otel/api/metric"
+	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregator"
+)
+
+// ErrUnimplementedAgg is returned when a transformation of an unimplemented
+// aggregator is attempted.
+var ErrUnimplementedAgg = errors.New("unimplemented aggregator")
+
+// Record transforms an OpenTelemetry Record into a Metric.
+//
+// An ErrUnimplementedAgg error is returned for unimplemented Aggregators.
+func Record(service string, r metricsdk.Record) (telemetry.Metric, error) {
+	desc := r.Descriptor()
+	attrs := attributes(service, desc, r.Labels())
+	switch a := r.Aggregator().(type) {
+	case aggregator.MinMaxSumCount:
+		return minMaxSumCount(desc, attrs, a)
+	case aggregator.Sum:
+		return sum(desc, attrs, a)
+	}
+	return nil, ErrUnimplementedAgg
+}
+
+// sum transforms a Sum Aggregator aggregation into a Count Metric.
+func sum(desc *metric.Descriptor, attrs map[string]interface{}, a aggregator.Sum) (telemetry.Metric, error) {
+	sum, err := a.Sum()
+	if err != nil {
+		return nil, err
+	}
+
+	return telemetry.Count{
+		Name:       desc.Name(),
+		Attributes: attrs,
+		Value:      sum.CoerceToFloat64(desc.NumberKind()),
+	}, nil
+}
+
+// minMaxSumCountValue returns the values of the MinMaxSumCount Aggregator
+// as discret values or any error returned from parsing any of the values.
+func minMaxSumCountValues(a aggregator.MinMaxSumCount) (min, max, sum core.Number, count int64, err error) {
+	if min, err = a.Min(); err != nil {
+		return
+	}
+	if max, err = a.Max(); err != nil {
+		return
+	}
+	if sum, err = a.Sum(); err != nil {
+		return
+	}
+	if count, err = a.Count(); err != nil {
+		return
+	}
+	return
+}
+
+// minMaxSumCount transforms a MinMaxSumCount aggregation into a Summary Metric.
+func minMaxSumCount(desc *metric.Descriptor, attrs map[string]interface{}, a aggregator.MinMaxSumCount) (telemetry.Metric, error) {
+	min, max, sum, count, err := minMaxSumCountValues(a)
+	if err != nil {
+		return nil, err
+	}
+
+	return telemetry.Summary{
+		Name:       desc.Name(),
+		Attributes: attrs,
+		Count:      float64(count),
+		Sum:        sum.CoerceToFloat64(desc.NumberKind()),
+		Min:        min.CoerceToFloat64(desc.NumberKind()),
+		Max:        max.CoerceToFloat64(desc.NumberKind()),
+	}, nil
+}
+
+func attributes(service string, desc *metric.Descriptor, labels metricsdk.Labels) map[string]interface{} {
+	resAttrs := desc.Resource().Attributes()
+	iter := labels.Iter()
+
+	attrs := make(map[string]interface{}, 5+iter.Len()+len(resAttrs))
+
+	// TODO (MrAlias): Add desc.LibrayName information here added in v0.4.
+	// Should be sent as instrumentation.name and instrumentation.version attributes.
+	attrs["unit"] = string(desc.Unit())
+	attrs["description"] = desc.Description()
+
+	for _, kv := range resAttrs {
+		attrs[string(kv.Key)] = kv.Value.AsInterface()
+	}
+
+	for iter.Next() {
+		kv := iter.Label()
+		attrs[string(kv.Key)] = kv.Value.AsInterface()
+	}
+
+	// New Relic registered attributes to identify where this data came from.
+	attrs[serviceNameAttrKey] = service
+	attrs[instrumentationProviderAttrKey] = instrumentationProviderAttrValue
+	attrs[collectorNameAttrKey] = collectorNameAttrValue
+
+	return attrs
+}

--- a/newrelic/internal/transform/metric_test.go
+++ b/newrelic/internal/transform/metric_test.go
@@ -1,0 +1,140 @@
+package transform
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/otel/api/core"
+	metricapi "go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/unit"
+	metricsdk "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+var defaultAttrs = map[string]string{
+	instrumentationProviderAttrKey: instrumentationProviderAttrValue,
+	collectorNameAttrKey:           collectorNameAttrValue,
+}
+
+func TestDefaultAttributes(t *testing.T) {
+	attrs := attributes("", nil, metricsdk.NewLabels(metricsdk.LabelSlice{}, "", nil))
+	if got, want := len(attrs), len(defaultAttrs); got != want {
+		t.Errorf("incorrect number of default attributes: got %d, want %d", got, want)
+	}
+}
+
+func TestServiceNameAttributes(t *testing.T) {
+	want := "test-service-name"
+	attrs := attributes(want, nil, metricsdk.NewLabels(metricsdk.LabelSlice{}, "", nil))
+	if got, ok := attrs[serviceNameAttrKey]; !ok || got != want {
+		t.Errorf("service.name attribute wrong: got %q, want %q", got, want)
+	}
+}
+
+func TestDescriptorAttributes(t *testing.T) {
+	for i, test := range []struct {
+		opts []metricapi.Option
+		want map[string]interface{}
+	}{
+		{
+			[]metricapi.Option{
+				metricapi.WithResource(*resource.New(core.Key("A").String("a"))),
+			},
+			map[string]interface{}{
+				"A": "a",
+			},
+		},
+		{
+			[]metricapi.Option{
+				metricapi.WithResource(*resource.New(core.Key("A").String("a"), core.Key("1").Int64(1))),
+			},
+			map[string]interface{}{
+				"A": "a",
+				"1": int64(1),
+			},
+		},
+		{
+			[]metricapi.Option{
+				metricapi.WithUnit(unit.Bytes),
+			},
+			map[string]interface{}{
+				"unit": "By",
+			},
+		},
+		{
+			[]metricapi.Option{
+				metricapi.WithDescription("test description"),
+			},
+			map[string]interface{}{
+				"description": "test description",
+			},
+		},
+		{
+			[]metricapi.Option{
+				metricapi.WithResource(*resource.New(core.Key("B").String("b"), core.Key("2").Int64(2))),
+				metricapi.WithUnit(unit.Milliseconds),
+				metricapi.WithDescription("test description 2"),
+			},
+			map[string]interface{}{
+				"B":           "b",
+				"2":           int64(2),
+				"unit":        "ms",
+				"description": "test description 2",
+			},
+		},
+	} {
+		name := fmt.Sprintf("descriptor test %d", i)
+		desc := metricapi.NewDescriptor(name, metricapi.CounterKind, core.Int64NumberKind, test.opts...)
+		expected := make(map[string]interface{}, len(defaultAttrs)+len(test.want))
+		for k, v := range defaultAttrs {
+			expected[k] = v
+		}
+		for k, v := range test.want {
+			expected[k] = v
+		}
+		got := attributes("", &desc, metricsdk.NewLabels(metricsdk.LabelSlice{}, "", nil))
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s: %#v != %#v", name, got, expected)
+		}
+	}
+}
+
+func TestLabelAttributes(t *testing.T) {
+	for i, test := range []struct {
+		labels []core.KeyValue
+		want   map[string]interface{}
+	}{
+		{
+			[]core.KeyValue{
+				core.Key("A").String("a"),
+			},
+			map[string]interface{}{
+				"A": "a",
+			},
+		},
+		{
+			[]core.KeyValue{
+				core.Key("A").String("a"),
+				core.Key("1").Int64(1),
+			},
+			map[string]interface{}{
+				"A": "a",
+				"1": int64(1),
+			},
+		},
+	} {
+		expected := make(map[string]interface{}, len(defaultAttrs)+len(test.want))
+		for k, v := range defaultAttrs {
+			expected[k] = v
+		}
+		for k, v := range test.want {
+			expected[k] = v
+		}
+		l := metricsdk.NewLabels(metricsdk.LabelSlice(test.labels), "", nil)
+		got := attributes("", nil, l)
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("labels test %d: %#v != %#v", i, got, expected)
+		}
+	}
+}

--- a/newrelic/internal/transform/span.go
+++ b/newrelic/internal/transform/span.go
@@ -47,8 +47,8 @@ func Span(service string, span *trace.SpanData) telemetry.Span {
 	}
 
 	return telemetry.Span{
-		ID:          span.SpanContext.SpanIDString(),
-		TraceID:     span.SpanContext.TraceIDString(),
+		ID:          span.SpanContext.SpanID.String(),
+		TraceID:     span.SpanContext.TraceID.String(),
 		Timestamp:   span.StartTime,
 		Name:        span.Name,
 		ParentID:    parentSpanID,


### PR DESCRIPTION
Add `Export` method to the `Exporter` to implement the `"go.opentelemetry.io/otel/sdk/export/metric".Exporter` interface.

Add transform logic to the `transform` package to handle OpenTelemetry `Record`s and transform them into New Relic `Metric`s.

Update existing end-to-end test validate metric exporting.