### PR TITLE
Upgrade to v0.13.0 of go.opentelemetry.io/otel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.3.0
-	go.opentelemetry.io/otel v0.12.0
-	go.opentelemetry.io/otel/sdk v0.12.0
+	go.opentelemetry.io/otel v0.13.0
+	go.opentelemetry.io/otel/sdk v0.13.0
 	google.golang.org/grpc v1.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,12 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opentelemetry.io/otel v0.12.0 h1:bwWaPd/h2q+U6KdKaAiOS5GLwOMd1LDt9iNaeyIoAI8=
 go.opentelemetry.io/otel v0.12.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
+go.opentelemetry.io/otel v0.13.0 h1:2isEnyzjjJZq6r2EKMsFj4TxiQiexsM04AVhwbR/oBA=
+go.opentelemetry.io/otel v0.13.0/go.mod h1:dlSNewoRYikTkotEnxdmuBHgzT+k/idJSfDv/FxEnOY=
 go.opentelemetry.io/otel/sdk v0.12.0 h1:YVUyDXsGvFWjhJxGXT4kBcGdfoTbo1vSGjbGRUdRh5U=
 go.opentelemetry.io/otel/sdk v0.12.0/go.mod h1:u3joRdxhrS1hUf9xSFH8vgdXdujQ3jxXxZl3loZFSqs=
+go.opentelemetry.io/otel/sdk v0.13.0 h1:4VCfpKamZ8GtnepXxMRurSpHpMKkcxhtO33z1S4rGDQ=
+go.opentelemetry.io/otel/sdk v0.13.0/go.mod h1:dKvLH8Uu8LcEPlSAUsfW7kMGaJBhk/1NYvpPZ6wIMbU=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/newrelic/internal/transform/span.go
+++ b/newrelic/internal/transform/span.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/semconv"
-	"google.golang.org/grpc/codes"
 )
 
 // Span transforms an OpenTelemetry SpanData into a New Relic Span for a
@@ -31,8 +31,8 @@ func Span(service string, span *trace.SpanData) telemetry.Span {
 		numAttrs++
 	}
 
-	// Consider everything other than an OK as an error.
-	isError := span.StatusCode != codes.OK
+	// Status of Ok and Unset are not considered errors.
+	isError := span.StatusCode == codes.Error
 	if isError {
 		numAttrs += 2
 	}

--- a/newrelic/internal/transform/span_test.go
+++ b/newrelic/internal/transform/span_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/label"
 	exporttrace "go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
-	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -93,7 +93,7 @@ func TestTransformSpans(t *testing.T) {
 					TraceID: sampleTraceID,
 					SpanID:  sampleSpanID,
 				},
-				StatusCode:    codes.ResourceExhausted,
+				StatusCode:    codes.Error,
 				StatusMessage: "ResourceExhausted",
 				StartTime:     now,
 				EndTime:       now.Add(2 * time.Second),
@@ -109,7 +109,7 @@ func TestTransformSpans(t *testing.T) {
 				Attributes: map[string]interface{}{
 					instrumentationProviderAttrKey: instrumentationProviderAttrValue,
 					collectorNameAttrKey:           collectorNameAttrValue,
-					errorCodeAttrKey:               uint32(codes.ResourceExhausted),
+					errorCodeAttrKey:               uint32(codes.Error),
 					errorMessageAttrKey:            "ResourceExhausted",
 				},
 			},
@@ -167,7 +167,7 @@ func TestTransformSpans(t *testing.T) {
 					TraceID: sampleTraceID,
 					SpanID:  sampleSpanID,
 				},
-				StatusCode:    codes.ResourceExhausted,
+				StatusCode:    codes.Error,
 				StatusMessage: "ResourceExhausted",
 				StartTime:     now,
 				EndTime:       now.Add(2 * time.Second),
@@ -187,7 +187,7 @@ func TestTransformSpans(t *testing.T) {
 					"x0":                           true,
 					instrumentationProviderAttrKey: instrumentationProviderAttrValue,
 					collectorNameAttrKey:           collectorNameAttrValue,
-					errorCodeAttrKey:               uint32(codes.ResourceExhausted),
+					errorCodeAttrKey:               uint32(codes.Error),
 					errorMessageAttrKey:            "ResourceExhausted",
 				},
 			},


### PR DESCRIPTION
- Bump go.opentelemetry.io/otel module version to v0.13.0.
- Update using the `otel/codes` package for span status to match the change from upstream.