### PR TITLE
Update span.go

### DIFF
--- a/newrelic/internal/transform/span.go
+++ b/newrelic/internal/transform/span.go
@@ -56,7 +56,7 @@ func Span(service string, span *trace.SpanData) telemetry.Span {
 	}
 
 	if span.SpanKind != apitrace.SpanKindUnspecified {
-		attrs["span.kind"] = strings.ToUpper(span.SpanKind.String())
+		attrs["span.kind"] = strings.ToLower(span.SpanKind.String())
 	}
 
 	// New Relic registered attributes to identify where this data came from.

--- a/newrelic/internal/transform/span_test.go
+++ b/newrelic/internal/transform/span_test.go
@@ -244,7 +244,7 @@ func TestTransformSpans(t *testing.T) {
 				ServiceName: "resource service",
 				Attributes: map[string]interface{}{
 					"service.name":                 "resource service",
-					"span.kind":                    "CLIENT",
+					"span.kind":                    "client",
 					instrumentationProviderAttrKey: instrumentationProviderAttrValue,
 					collectorNameAttrKey:           collectorNameAttrValue,
 				},


### PR DESCRIPTION
Span kinds are lowercase internal to New Relic. Avoid the downstream conversion by sending the correct format here.