### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,27 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2020-12-04
+
 ### Changed
 
 - Upgrade `go.opentelemetry.io/otel*` to v0.14.0. (#40)
 
 ## [0.13.0] - 2020-10-28
+
 ### Added
+
 - Support for metrics (#10)
 - Version number has been modified to track the version numbers of the
   go.opentelemetry.io/otel upstream library.
 
 ### Changed
+
 - Updated to use version 0.13.0 of the go.opentelemetry.io/otel packages. (#30)
 - Standardized CHANGELOG.md format. When making changes to this project, add
   human-readable summaries of what you've done to the "Unreleased" section
@@ -23,8 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   section in this document. (#35)
 
 ## [0.1.0] - 2019-12-31
+
 First release!
 
-[Unreleased]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.1.0...v0.13.0
 [0.1.0]: https://github.com/newrelic/opentelemetry-exporter-go/releases/tag/v0.1.0


### PR DESCRIPTION
### Changed

- Upgrade `go.opentelemetry.io/otel*` to v0.14.0. (#40)