### PR TITLE
OpenTelemetry simple sample application

### DIFF
--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.5.1
-	github.com/newrelic/opentelemetry-exporter-go v0.14.0
-	go.opentelemetry.io/otel v0.15.0
-	go.opentelemetry.io/otel/sdk v0.15.0
+	github.com/newrelic/opentelemetry-exporter-go v0.16.0
+	go.opentelemetry.io/otel v0.16.0
+	go.opentelemetry.io/otel/sdk v0.16.0
 )

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -1,0 +1,11 @@
+module github.com/newrelic/opentelemetry-exporter-go/examples
+
+go 1.15
+
+require (
+	github.com/newrelic/newrelic-telemetry-sdk-go v0.5.1
+	github.com/newrelic/opentelemetry-exporter-go v0.14.0
+	go.opentelemetry.io/otel v0.15.0
+	go.opentelemetry.io/otel/exporters/stdout v0.15.0
+	go.opentelemetry.io/otel/sdk v0.15.0
+)

--- a/examples/simple/go.mod
+++ b/examples/simple/go.mod
@@ -1,4 +1,4 @@
-module github.com/newrelic/opentelemetry-exporter-go/examples
+module github.com/newrelic/opentelemetry-exporter-go/examples/simple
 
 go 1.15
 
@@ -6,6 +6,5 @@ require (
 	github.com/newrelic/newrelic-telemetry-sdk-go v0.5.1
 	github.com/newrelic/opentelemetry-exporter-go v0.14.0
 	go.opentelemetry.io/otel v0.15.0
-	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0
 )

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
 	"github.com/newrelic/opentelemetry-exporter-go/newrelic"
@@ -46,8 +45,10 @@ func main() {
 		fmt.Printf("failed to instantiate New Relic OpenTelemetry exporter: %v\n", err)
 	}
 
-	// Create a tracer provider
 	ctx := context.Background()
+	defer exporter.Shutdown(ctx)
+
+	// Create a tracer provider
 	bsp := sdktrace.NewBatchSpanProcessor(exporter)
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(bsp))
 	defer func() { _ = tp.Shutdown(ctx) }()
@@ -125,6 +126,4 @@ func main() {
 		}(ctx)
 	}(ctx)
 
-	// Wait for the New Relic OpenTelemetry Exporter to send data to New Relic
-	time.Sleep(20 * time.Second)
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,0 +1,130 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This example script is the sample from the OpenTelemetry Go "Getting Started"
+// guide, with the text-based exporter replaced with the New Relic OpenTelemetry
+// Exporter.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+	"github.com/newrelic/opentelemetry-exporter-go/newrelic"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/metric/controller/push"
+	"go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func main() {
+
+	// Create a New Relic OpenTelemetry Exporter
+	apiKey, ok := os.LookupEnv("NEW_RELIC_API_KEY")
+	if !ok {
+		fmt.Println("missing NEW_RELIC_API_KEY required for New Relic OpenTelemetry Exporter")
+	}
+
+	exporter, err := newrelic.NewExporter(
+		"Sample OpenTelemetry Service",
+		apiKey,
+		telemetry.ConfigBasicErrorLogger(os.Stderr),
+		telemetry.ConfigBasicDebugLogger(os.Stderr),
+		telemetry.ConfigBasicAuditLogger(os.Stderr),
+	)
+	if err != nil {
+		fmt.Printf("failed to instantiate New Relic OpenTelemetry exporter: %v\n", err)
+	}
+
+	// Create a tracer provider
+	ctx := context.Background()
+	bsp := sdktrace.NewBatchSpanProcessor(exporter)
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(bsp))
+	defer func() { _ = tp.Shutdown(ctx) }()
+
+	// Create a meter provider
+	pusher := push.New(
+		basic.New(
+			simple.NewWithExactDistribution(),
+			exporter,
+		),
+		exporter,
+	)
+	pusher.Start()
+	defer pusher.Stop()
+
+	// Set global options
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(pusher.MeterProvider())
+	propagator := propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})
+	otel.SetTextMapPropagator(propagator)
+
+	// Sample metric instruments
+	fooKey := label.Key("ex.com/foo")
+	barKey := label.Key("ex.com/bar")
+	lemonsKey := label.Key("ex.com/lemons")
+	anotherKey := label.Key("ex.com/another")
+
+	commonLabels := []label.KeyValue{lemonsKey.Int(10), label.String("A", "1"), label.String("B", "2"), label.String("C", "3")}
+
+	meter := otel.Meter("ex.com/basic")
+
+	observerCallback := func(_ context.Context, result metric.Float64ObserverResult) {
+		result.Observe(1, commonLabels...)
+	}
+	_ = metric.Must(meter).NewFloat64ValueObserver("ex.com.one", observerCallback,
+		metric.WithDescription("A ValueObserver set to 1.0"),
+	)
+
+	valueRecorder := metric.Must(meter).NewFloat64ValueRecorder("ex.com.two")
+
+	boundRecorder := valueRecorder.Bind(commonLabels...)
+	defer boundRecorder.Unbind()
+
+	// Create a trace and some measurements
+	tracer := otel.Tracer("ex.com/basic")
+	ctx = baggage.ContextWithValues(ctx,
+		fooKey.String("foo1"),
+		barKey.String("bar1"),
+	)
+
+	func(ctx context.Context) {
+		var span trace.Span
+		ctx, span = tracer.Start(ctx, "operation")
+		defer span.End()
+
+		span.AddEvent("Nice operation!", trace.WithAttributes(label.Int("bogons", 100)))
+		span.SetAttributes(anotherKey.String("yes"))
+
+		meter.RecordBatch(
+			// Note: call-site variables added as context Entries:
+			baggage.ContextWithValues(ctx, anotherKey.String("xyz")),
+			commonLabels,
+
+			valueRecorder.Measurement(2.0),
+		)
+
+		func(ctx context.Context) {
+			var span trace.Span
+			ctx, span = tracer.Start(ctx, "Sub operation...")
+			defer span.End()
+
+			span.SetAttributes(lemonsKey.String("five"))
+			span.AddEvent("Sub span event")
+			boundRecorder.Record(ctx, 1.3)
+		}(ctx)
+	}(ctx)
+
+	// Wait for the New Relic OpenTelemetry Exporter to send data to New Relic
+	time.Sleep(20 * time.Second)
+}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -31,18 +31,20 @@ func main() {
 	// Create a New Relic OpenTelemetry Exporter
 	apiKey, ok := os.LookupEnv("NEW_RELIC_API_KEY")
 	if !ok {
-		fmt.Println("missing NEW_RELIC_API_KEY required for New Relic OpenTelemetry Exporter")
+		fmt.Println("Missing NEW_RELIC_API_KEY required for New Relic OpenTelemetry Exporter")
+		os.Exit(1)
 	}
 
 	exporter, err := newrelic.NewExporter(
-		"Sample OpenTelemetry Service",
+		"Simple OpenTelemetry Service",
 		apiKey,
 		telemetry.ConfigBasicErrorLogger(os.Stderr),
 		telemetry.ConfigBasicDebugLogger(os.Stderr),
 		telemetry.ConfigBasicAuditLogger(os.Stderr),
 	)
 	if err != nil {
-		fmt.Printf("failed to instantiate New Relic OpenTelemetry exporter: %v\n", err)
+		fmt.Printf("Failed to instantiate New Relic OpenTelemetry exporter: %v\n", err)
+		os.Exit(1)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
This is a very simple Go application, based off of @krnowak 's excellent Getting Started guide, which substitutes the New Relic OpenTelemetry Exporter for the `stdout` exporter in the original example. 

It's a supporting document for New Relic's OpenTelemetry documentation. Run it like this:

```
NEW_RELIC_API_KEY=<New Relic Insert API Key> go run main.go
```

...where that key is obtained from the New Relic One UI [according to these quick instructions](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events#register).

It works for me, I'd love to hear others' experiences with it before it becomes part of our official documentation.