### PR TITLE
examples explicitly set otel metric exporter inside controller

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -62,6 +62,7 @@ func main() {
 			simple.NewWithExactDistribution(),
 			exporter,
 		),
+		controller.WithPusher(exporter),
 	)
 
 	err = pusher.Start(ctx)


### PR DESCRIPTION
I tried example locally and I believe that otel metrics are not exported properly (I can't see any metrics in newrelic UI) .

As far as I see the issue is cased by the fact that for metrics controller exporter needs to be explicitly set in https://github.com/open-telemetry/opentelemetry-go/blob/v0.16.0/sdk/metric/controller/basic/controller.go#L97 otherwise on actual metrics exporting next code path will be triggered https://github.com/open-telemetry/opentelemetry-go/blob/v0.16.0/sdk/metric/controller/basic/controller.go#L192 hence no metrics will be exported to newrelic.