### PR TITLE
Ready for v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
-## [0.18.0] - 2021-04-05
+## [0.18.0] - 2021-04-06
 
 ### Changed
  - Upgraded `go.opentelemetry.io/otel*` dependencies to v0.19.0. Thanks to @akulnurislam for getting us to v0.18.0! ([#71](https://github.com/newrelic/opentelemetry-exporter-go/pull/71), [#74](https://github.com/newrelic/opentelemetry-exporter-go/pull/74))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+
+## [0.18.0] - 2021-04-05
+
 ### Changed
- - Upgraded `go.opentelemetry.io/otel*` dependencies to v0.19.0. Thanks to @akulnurislam for getting us to v0.18.0! ([#71](https://github.com/newrelic/opentelemetry-exporter-go/pull/71), [#74]((https://github.com/newrelic/opentelemetry-exporter-go/pull/74)))
+ - Upgraded `go.opentelemetry.io/otel*` dependencies to v0.19.0. Thanks to @akulnurislam for getting us to v0.18.0! ([#71](https://github.com/newrelic/opentelemetry-exporter-go/pull/71), [#74](https://github.com/newrelic/opentelemetry-exporter-go/pull/74))
+
+### Added
+- Clarified language and examples in the sample application for customers using 
+New Relic's EU datacenter.
 
 ## [0.17.0] - 2021-03-04
 
@@ -55,7 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 First release!
 
-[Unreleased]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.15.1...v0.17.0
 [0.15.1]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.14.0...v0.15.1
 [0.14.0]: https://github.com/newrelic/opentelemetry-exporter-go/compare/v0.13.0...v0.14.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The `"github.com/newrelic/opentelemetry-exporter-go/newrelic"` package
 provides an exporter for sending OpenTelemetry data to New Relic.  Currently,
-traces and the latest metric instruments (as of v0.13 of Open Telemetry) are
+traces and the latest metric instruments (as of v0.19 of Open Telemetry for Go) are
 supported.
 
 

--- a/newrelic/exporter.go
+++ b/newrelic/exporter.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	version          = "0.1.0"
+	version          = "0.18.0"
 	userAgentProduct = "NewRelic-Go-OpenTelemetry"
 )
 
@@ -68,7 +68,7 @@ func NewExporter(service, apiKey string, options ...func(*telemetry.Config)) (*E
 }
 
 // NewExportPipeline creates a new OpenTelemetry telemetry pipeline using a
-// New Relic Exporter configured with default setting. It is the callers
+// New Relic Exporter configured with default setting. It is the caller's
 // responsibility to stop the returned OTel Controller. This function uses the
 // following environment variables to configure the exporter installed in the
 // pipeline:
@@ -133,12 +133,12 @@ func NewExportPipeline(service string, traceOpt []sdktrace.TracerProviderOption,
 }
 
 // InstallNewPipeline installs a New Relic exporter with default settings
-// in the global OpenTelemetry telemetry pipeline. It is the callers
-// responsibility to stop the returned push Controller. 
+// in the global OpenTelemetry telemetry pipeline. It is the caller's
+// responsibility to stop the returned push Controller.
 // ## Prerequisites
 // For details, check out the "Get Started" section of [New Relic Go OpenTelemetry exporter](https://github.com/newrelic/opentelemetry-exporter-go/blob/master/README.md#get-started).
 // ## Environment variables
-// This function uses the following environment variables to configure 
+// This function uses the following environment variables to configure
 // the exporter installed in the pipeline:
 //    * `NEW_RELIC_API_KEY`: New Relic Insights insert key.
 //    * `NEW_RELIC_METRIC_URL`: Override URL to New Relic metric endpoint.


### PR DESCRIPTION
This follows **[Step 3](https://github.com/newrelic/opentelemetry-exporter-go/wiki/Release-Checklist#3-final-release-pr)** of the release checklist. Ready for review!